### PR TITLE
CircuitBreakerOpenException removed

### DIFF
--- a/Chapter13/microservices/product-composite-service/src/main/java/se/magnus/microservices/composite/product/services/ProductCompositeServiceImpl.java
+++ b/Chapter13/microservices/product-composite-service/src/main/java/se/magnus/microservices/composite/product/services/ProductCompositeServiceImpl.java
@@ -1,6 +1,10 @@
 package se.magnus.microservices.composite.product.services;
 
+/* Below import is changed to -> import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerOpenException;
+*/
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+//*******************************************************************
 import io.github.resilience4j.reactor.retry.RetryExceptionWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,7 +89,9 @@ public class ProductCompositeServiceImpl implements ProductCompositeService {
                 ReactiveSecurityContextHolder.getContext().defaultIfEmpty(nullSC),
                 integration.getProduct(productId, delay, faultPercent)
                     .onErrorMap(RetryExceptionWrapper.class, retryException -> retryException.getCause())
-                    .onErrorReturn(CircuitBreakerOpenException.class, getProductFallbackValue(productId)),
+  /* CircuitBreakerOpenException.class is deprecated and removed from the library : Replaced with CallNotPermittedException.class*/
+                    //.onErrorReturn(CircuitBreakerOpenException.class, getProductFallbackValue(productId)),
+                    .onErrorReturn(CallNotPermittedException.class, getProductFallbackValue(productId)),
                 integration.getRecommendations(productId).collectList(),
                 integration.getReviews(productId).collectList())
             .doOnError(ex -> LOG.warn("getCompositeProduct failed: {}", ex.toString()))


### PR DESCRIPTION
CircuitBreakerOpenException.class is deprecated and removed from the library : Replaced with CallNotPermittedException.class

.onErrorReturn(CallNotPermittedException.class, getProductFallbackValue(productId)),
instead of
.onErrorReturn(CircuitBreakerOpenException.class, getProductFallbackValue(productId)),