### PR TITLE
remove usage of ReactiveHealthIndicatorRegistry (deprecated)

### DIFF
--- a/Chapter07/microservices/product-composite-service/src/main/java/se/magnus/microservices/composite/product/ProductCompositeServiceApplication.java
+++ b/Chapter07/microservices/product-composite-service/src/main/java/se/magnus/microservices/composite/product/ProductCompositeServiceApplication.java
@@ -14,6 +14,7 @@ import springfox.documentation.service.Contact;
 import springfox.documentation.spring.web.plugins.Docket;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
@@ -63,21 +64,17 @@ public class ProductCompositeServiceApplication {
     }
 
 	@Autowired
-	HealthAggregator healthAggregator;
-
-	@Autowired
 	ProductCompositeIntegration integration;
 
 	@Bean
-	ReactiveHealthIndicator coreServices() {
+	ReactiveHealthContributor coreServices() {
+		final Map<String, ReactiveHealthIndicator> registry = new LinkedHashMap<>();
 
-		ReactiveHealthIndicatorRegistry registry = new DefaultReactiveHealthIndicatorRegistry(new LinkedHashMap<>());
+		registry.put("product", () -> integration.getProductHealth());
+		registry.put("recommendation", () -> integration.getRecommendationHealth());
+		registry.put("review", () -> integration.getReviewHealth());
 
-		registry.register("product", () -> integration.getProductHealth());
-		registry.register("recommendation", () -> integration.getRecommendationHealth());
-		registry.register("review", () -> integration.getReviewHealth());
-
-		return new CompositeReactiveHealthIndicator(healthAggregator, registry);
+		return CompositeReactiveHealthContributor.fromMap(registry);
 	}
 
 	public static void main(String[] args) {


### PR DESCRIPTION
ReactiveHealthIndicatorRegistry and CompositeReactiveHealthIndicator are deprecated since 2.2.0. I changed the code to use:
ReactiveHealthContributor and CompositeReactiveHealthContributor instead.