### PR TITLE
RabbitMQ management webpage

### DIFF
--- a/Chapter07/docker-compose.yml
+++ b/Chapter07/docker-compose.yml
@@ -82,6 +82,8 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
+    # Enable the web management page on port 15672 : http://127.0.0.1/15672 Username: guest, Password: guest
+    command: rabbitmq-plugins enable rabbitmq_management
     healthcheck:
       test: ["CMD", "rabbitmqctl", "status"]
       interval: 10s


### PR DESCRIPTION
Page 231: Unable to access the RabbitMQ management page by default on http://locahost:15672/#/queues

The management plugin is not enabled by default, a command needs to be run in order to enable it: (see https://www.rabbitmq.com/management.html)

Add the following command line to its definition on the docker-compose.yml file as follows:
command: rabbitmq-plugins enable rabbitmq_management